### PR TITLE
version dep on D2PAE depends on current D2 version (or lack of D2)

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,7 +20,17 @@ WriteMakefile(
     PREREQ_PM => {
         'Carp'                              => 0,
         'Dancer2::Core::Types'              => 0,
-        'Dancer2::Plugin::Auth::Extensible' => '0.620',
+        'Dancer2::Plugin::Auth::Extensible' => eval {
+            # Dancer2 v0.300001 switched to RFC 7231 behaviour for redirects,
+            # breaking Dancer2::Plugin::Auth::Extensible::Test which our
+            # tests rely on. If Dancer2 is installed and is below this
+            # version then we can survive with D2PAE v0.620, otherwise
+            # we need v0.709 which includes test fixes.
+            require Dancer2;
+            my $d2_version = $Dancer2::VERSION;
+            $d2_version =~ s/_.*//;
+            $d2_version < 0.300001 ? '0.620' : 0;
+        } || '0.709',
         'Moo'                               => '2.000000',
         'namespace::clean'                  => 0,
         'Net::LDAP'                         => 0,


### PR DESCRIPTION
Due to D2 v0.300001 now using RFC 7231 behavior for redirects which can break our tests. D2PAE v0.709 handles this new behaviour in tests so we require the newer version if we have D2  0.300001 or newer, or if D2 is not yet installed.

@cromedome seems more reasonable then forcing a new dep on D2PAE. Thoughts?