### PR TITLE
Hotfix/anonymous bind

### DIFF
--- a/lib/Dancer2/Plugin/Auth/Extensible/Provider/LDAP.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible/Provider/LDAP.pm
@@ -213,8 +213,12 @@ Returns a connected L<Net::LDAP> object.
 
 sub ldap {
     my $self = shift;
-    Net::LDAP->new( $self->host, %{ $self->options } )
-      or croak "LDAP connect failed for: " . $self->host;
+    unless (defined $self->{ldap})
+    {
+       $self->{ldap} = Net::LDAP->new( $self->host, %{ $self->options } )
+         or croak "LDAP connect failed for: " . $self->host;
+    }
+    return $self->{ldap};
 }
 
 =head2 authenticate_user $username, $password
@@ -231,7 +235,7 @@ sub authenticate_user {
 
     my $ldap = $self->ldap or return;
 
-    my $mesg = $self->_bind_ldap( $user->{dn}, password => $password );
+    my $mesg = $self->_bind_ldap( $user->{dn}, password => $password);
 
     $ldap->unbind;
     $ldap->disconnect;

--- a/lib/Dancer2/Plugin/Auth/Extensible/Provider/LDAP.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible/Provider/LDAP.pm
@@ -179,6 +179,17 @@ has role_member_attribute => (
     default => 'member',
 );
 
+sub _unbind_ldap {
+    my ( $self ) = @_;
+
+    my $ldap = $self->ldap or return;
+
+    $ldap->unbind;
+    $ldap->disconnect;
+
+    $self->{ldap} = undef;
+}
+
 sub _bind_ldap {
     my ( $self, $username, $dummy, $password ) = @_;
 
@@ -237,8 +248,7 @@ sub authenticate_user {
 
     my $mesg = $self->_bind_ldap( $user->{dn}, password => $password);
 
-    $ldap->unbind;
-    $ldap->disconnect;
+    $self->_unbind_ldap;
 
     return not $mesg->is_error;
 }
@@ -312,8 +322,7 @@ sub get_user_details {
             debug => "User not found via LDAP: $username" );
     }
 
-    $ldap->unbind;
-    $ldap->disconnect;
+    $self->_unbind_ldap;
 
     return $user;
 }


### PR DESCRIPTION
This change should adress the issue described in #8.

It assures that only one ldap object is created.
Otherwise a second connection is opened and only one gets binded and authenticated with the credentials.