### PR TITLE
Hotfix/anonymous bind

### DIFF
--- a/lib/Dancer2/Plugin/Auth/Extensible/Provider/LDAP.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible/Provider/LDAP.pm
@@ -229,8 +229,12 @@ Returns a connected L<Net::LDAP> object.
 
 sub ldap {
     my $self = shift;
-    Net::LDAP->new( $self->host, %{ $self->options } )
-      or croak "LDAP connect failed for: " . $self->host;
+    unless (defined $self->{ldap})
+    {
+       $self->{ldap} = Net::LDAP->new( $self->host, %{ $self->options } )
+         or croak "LDAP connect failed for: " . $self->host;
+    }
+    return $self->{ldap};
 }
 
 =head2 authenticate_user $username, $password
@@ -247,7 +251,7 @@ sub authenticate_user {
 
     my $ldap = $self->ldap or return;
 
-    my $mesg = $self->_bind_ldap( $user->{dn}, password => $password );
+    my $mesg = $self->_bind_ldap( $user->{dn}, password => $password);
 
     $ldap->unbind;
     $ldap->disconnect;

--- a/lib/Dancer2/Plugin/Auth/Extensible/Provider/LDAP.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible/Provider/LDAP.pm
@@ -195,6 +195,17 @@ has role_member_attribute => (
     default => 'member',
 );
 
+sub _unbind_ldap {
+    my ( $self ) = @_;
+
+    my $ldap = $self->ldap or return;
+
+    $ldap->unbind;
+    $ldap->disconnect;
+
+    $self->{ldap} = undef;
+}
+
 sub _bind_ldap {
     my ( $self, $username, $dummy, $password ) = @_;
 
@@ -253,8 +264,7 @@ sub authenticate_user {
 
     my $mesg = $self->_bind_ldap( $user->{dn}, password => $password);
 
-    $ldap->unbind;
-    $ldap->disconnect;
+    $self->_unbind_ldap;
 
     return not $mesg->is_error;
 }
@@ -334,8 +344,7 @@ sub get_user_details {
             debug => "User not found via LDAP: $username" );
     }
 
-    $ldap->unbind;
-    $ldap->disconnect;
+    $self->_unbind_ldap;
 
     return $user;
 }


### PR DESCRIPTION
Original comment from modified PR #11:

This change should adress the issue described in https://github.com/PerlDancer/Dancer2-Plugin-Auth-Extensible-Provider-LDAP/issues/8.

It assures that only one ldap object is created.
Otherwise a second connection is opened and only one gets binded and authenticated with the credentials.

This PR also converts the `ldap` method to an attribute.